### PR TITLE
Chained route without route method

### DIFF
--- a/src/hono.ts
+++ b/src/hono.ts
@@ -108,6 +108,7 @@ export class Hono {
   addRoute(method: string, arg: string | Handler, ...args: Handler[]): Hono {
     method = method.toUpperCase()
     if (typeof arg === 'string') {
+      this.tempPath = arg
       this.router.add(method, arg, args)
     } else {
       args.unshift(arg)

--- a/test/hono.test.ts
+++ b/test/hono.test.ts
@@ -65,6 +65,27 @@ describe('Routing', () => {
     res = await app.dispatch(req)
     expect(res.status).toBe(404)
   })
+
+  it('Chained route without route method', async () => {
+    app
+      .get('/without-route', () => new Response('get /without-route'))
+      .post(() => new Response('post /without-route'))
+      .put(() => new Response('put /without-route'))
+
+    let req = new Request('/without-route', { method: 'GET' })
+    let res = await app.dispatch(req)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('get /without-route')
+
+    req = new Request('/without-route', { method: 'POST' })
+    res = await app.dispatch(req)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('post /without-route')
+
+    req = new Request('/without-route', { method: 'DELETE' })
+    res = await app.dispatch(req)
+    expect(res.status).toBe(404)
+  })
 })
 
 describe('params and query', () => {


### PR DESCRIPTION
fixed #25

You can write `app.get('/foo', ()=>{}).post(() => {})` 