### PR TITLE
feat(body-parse): a body parse middleware

### DIFF
--- a/example/basic/index.js
+++ b/example/basic/index.js
@@ -7,6 +7,7 @@ const app = new Hono()
 // Mount Builtin Middleware
 app.use('*', Middleware.poweredBy())
 app.use('*', Middleware.logger())
+app.use('/form', Middleware.bodyParse())
 app.use(
   '/auth/*',
   Middleware.basicAuth({
@@ -76,6 +77,11 @@ app.get('/api/posts', (c) => {
 })
 // status code
 app.post('/api/posts', (c) => c.json({ message: 'Created!' }, 201))
+
+app.post('/form', async (ctx) => {
+  return ctx.json(ctx.req.parsedBody || {})
+//return new Response('ok /form')
+})
 
 // addEventListener
 app.fire()

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -13,6 +13,7 @@ declare global {
   interface Request {
     params: (key: string) => string
     query: (key: string) => string | null
+    parsedBody: any
   }
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,10 +2,12 @@ import { defaultMiddleware } from './middleware/default'
 import { poweredBy } from './middleware/powered-by/powered-by'
 import { logger } from './middleware/logger/logger'
 import { basicAuth } from './middleware/basic-auth/basic-auth'
+import { bodyParse } from './middleware/body-parse/body-parse'
 
 export class Middleware {
   static default = defaultMiddleware
   static poweredBy = poweredBy
   static logger = logger
   static basicAuth = basicAuth
+  static bodyParse = bodyParse
 }

--- a/src/middleware/body-parse/body-parse.test.ts
+++ b/src/middleware/body-parse/body-parse.test.ts
@@ -1,0 +1,68 @@
+import makeServiceWorkerEnv from 'service-worker-mock'
+import { Hono, Middleware } from '../../hono'
+// eslint-disable-next-line node/no-extraneous-require
+const FormData = require('form-data')
+
+declare let global: any
+Object.assign(global, makeServiceWorkerEnv())
+
+describe('Parse Body Middleware', () => {
+  const app = new Hono()
+
+  app.use('*', Middleware.bodyParse())
+  app.post('/json', async (ctx) => {
+    return ctx.json(ctx.req.parsedBody, 200)
+  })
+  app.post('/text', async (ctx) => {
+    return ctx.text(ctx.req.parsedBody, 200)
+  })
+  app.post('/form', async (ctx) => {
+    return ctx.json(ctx.req.parsedBody, 200)
+  })
+
+  it('POST with JSON', async () => {
+    const payload = { message: 'hello hono' }
+    const req = new Request('/json', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+    })
+    const res = await app.dispatch(req)
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(req.parsedBody).toEqual(payload)
+    expect(await res.json()).toEqual(payload)
+  })
+
+  it.only('POST with text', async () => {
+    const payload = 'hello'
+    const req = new Request('/text', {
+      method: 'POST',
+      body: 'hello',
+      headers: new Headers({ 'Content-Type': 'application/text' }),
+    })
+    const res = await app.dispatch(req)
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(req.parsedBody).toEqual(payload)
+    expect(await res.text()).toEqual(payload)
+  })
+
+  // NOTE the service-worker-mock does not support req.formData()
+  // so disable this test case, but verify it on live cloudflare worker,
+  // it works, tracked by https://github.com/yusukebe/hono/issues/40
+  it.skip('POST with form', async () => {
+    const formData = new FormData()
+    formData.append('message', 'hello')
+    const req = new Request('/form', {
+      method: 'POST',
+      body: formData,
+      headers: formData.getHeaders(),
+    })
+    const res = await app.dispatch(req)
+    expect(res).not.toBeNull()
+    expect(res.status).toBe(200)
+    expect(req.parsedBody).toEqual({ message: 'hello' })
+    expect(await res.json()).toEqual({ message: 'hello' })
+  })
+})

--- a/src/middleware/body-parse/body-parse.ts
+++ b/src/middleware/body-parse/body-parse.ts
@@ -1,0 +1,23 @@
+import type { Context } from '../../context'
+
+export const bodyParse = () => {
+  return async (ctx: Context, next: Function) => {
+    const contentType = ctx.req.headers.get('Content-Type') || ''
+    if (contentType.includes('application/json')) {
+      ctx.req.parsedBody = await ctx.req.json()
+    } else if (contentType.includes('application/text')) {
+      ctx.req.parsedBody = await ctx.req.text()
+    } else if (contentType.includes('text/html')) {
+      ctx.req.parsedBody = await ctx.req.text()
+    } else if (contentType.includes('form')) {
+      const form: { [key: string]: string | File } = {}
+      const data = [...(await ctx.req.formData())].reduce((acc, cur) => {
+        acc[cur[0]] = cur[1]
+        return acc
+      }, form)
+      ctx.req.parsedBody = data
+    }
+
+    await next()
+  }
+}


### PR DESCRIPTION
Hi @yusukebe , not sure it's good idea or not if *Hono* provides a built-in `body-parse` middleware to handle the `json`, `xml` and `form` payload for `POST` method.  
This is just a simple PR to explain what it maybe like,  which is not ready for review, just for a better discussion. 