### PR TITLE
fix: basic auth

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,5 +1,6 @@
 // Based on the code in the MIT licensed `koa-compose` package.
 export const compose = (middleware: any) => {
+  const errors: Error[] = []
   return function (context: any, next?: Function) {
     let index = -1
     return dispatch(0)
@@ -10,7 +11,10 @@ export const compose = (middleware: any) => {
       if (i === middleware.length) fn = next
       if (!fn) return Promise.resolve()
       try {
-        return Promise.resolve(fn(context, dispatch.bind(null, i + 1)))
+        return Promise.resolve(fn(context, dispatch.bind(null, i + 1))).catch((e) => {
+          errors.push(e)
+          throw errors[0] // XXX
+        })
       } catch (err) {
         return Promise.reject(err)
       }

--- a/src/middleware/mustache/README.md
+++ b/src/middleware/mustache/README.md
@@ -2,7 +2,7 @@
 
 Mustache Middleware is available only on Cloudflare Workers.
 
-## Dependencies
+## Requirements
 
 This middleware depends on [mustache.js](https://www.npmjs.com/package/mustache).
 
@@ -22,10 +22,11 @@ index.js:
 
 ```js
 import { Hono, Middleware } from 'hono'
+import { mustache } from 'hono/mustache'
 
 const app = new Hono()
 
-app.use('*', Middleware.mustache())
+app.use('*', mustache())
 
 app.get('/', (c) => {
   return c.render(

--- a/src/middleware/mustache/mustache.ts
+++ b/src/middleware/mustache/mustache.ts
@@ -11,7 +11,7 @@ export const mustache = () => {
     try {
       Mustache = require('mustache')
     } catch {
-      throw new Error('If you want to use Mustache Middleware, install mustache package first.')
+      throw new Error('If you want to use Mustache Middleware, install "mustache" package first.')
     }
 
     c.render = async (filename, view = {}, options?) => {


### PR DESCRIPTION
Installing `buffer` and `crypto` packages enables basic auth, if `buffer` of `crypto` is not in pollyfills such as webpack 5 environment.

Close #82