### PR TITLE
feat: Basic-auth with polyfill

### DIFF
--- a/examples/compute-at-edge/index.js
+++ b/examples/compute-at-edge/index.js
@@ -1,13 +1,12 @@
 import { Hono } from 'hono'
+import { basicAuth } from '../../dist/middleware/basic-auth/basic-auth'
 
 const app = new Hono()
 
-app.use('*', async (c, next) => {
-  console.log(`[${c.req.method}] ${c.req.url}`)
-  next()
-})
+app.use('/auth/*', basicAuth({ username: 'hono', password: 'acoolproject' }))
 
 app.get('/', (c) => c.text('Hono!! Compute@Edge!!'))
+app.get('/auth/*', (c) => c.text('Your authorized!'))
 
 app.get('/hello/:name', (c) => {
   return c.text(`Hello ${c.req.param('name')}!!!!!`)

--- a/examples/compute-at-edge/index.js
+++ b/examples/compute-at-edge/index.js
@@ -1,4 +1,4 @@
-import { Hono } from 'hono'
+import { Hono } from '../../dist/hono'
 import { basicAuth } from '../../dist/middleware/basic-auth/basic-auth'
 
 const app = new Hono()

--- a/examples/compute-at-edge/package.json
+++ b/examples/compute-at-edge/package.json
@@ -9,12 +9,13 @@
     "url": "https://github.com/yusukebe/hono.git"
   },
   "homepage": "https://github.com/yusukebe/hono",
-  "engines": {
-    "node": "^16"
-  },
   "devDependencies": {
+    "buffer": "^6.0.3",
     "core-js": "^3.19.1",
-    "webpack": "^5.64.0",
+    "crypto-browserify": "^3.12.0",
+    "process": "^0.11.10",
+    "stream-browserify": "^3.0.0",
+    "webpack": "^5.68.0",
     "webpack-cli": "^4.9.1"
   },
   "dependencies": {
@@ -23,6 +24,7 @@
   },
   "scripts": {
     "prebuild": "webpack",
+    "dev": "fastly compute serve",
     "build": "js-compute-runtime --skip-pkg bin/index.js bin/main.wasm",
     "deploy": "npm run build && fastly compute deploy"
   }

--- a/examples/compute-at-edge/webpack.config.js
+++ b/examples/compute-at-edge/webpack.config.js
@@ -5,11 +5,19 @@ module.exports = {
   optimization: {
     minimize: true,
   },
-  target: 'webworker',
+  target: ['webworker'],
   output: {
     filename: 'index.js',
     path: path.resolve(__dirname, 'bin'),
     libraryTarget: 'this',
+  },
+  resolve: {
+    fallback: {
+      buffer: require.resolve('buffer/'),
+      crypto: require.resolve('crypto-browserify'),
+      stream: require.resolve('stream-browserify'),
+      process: require.resolve('process/browser'),
+    },
   },
   mode: 'production',
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono",
-  "version": "0.3.2",
+  "version": "0.3.3-pre",
   "description": "[炎] Ultrafast web framework for Cloudflare Workers.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/middleware/basic-auth/basic-auth.ts
+++ b/src/middleware/basic-auth/basic-auth.ts
@@ -1,5 +1,5 @@
 import type { Context } from '../../context'
-import { timingSafeEqual } from '../../utils/buffer'
+import { timingSafeEqual, decodeBase64 } from '../../utils/buffer'
 
 const CREDENTIALS_REGEXP = /^ *(?:[Bb][Aa][Ss][Ii][Cc]) +([A-Za-z0-9._~+/-]+=*) *$/
 const USER_PASS_REGEXP = /^([^:]*):(.*)$/
@@ -29,22 +29,6 @@ const auth = (req: Request) => {
   }
 
   return { username: userPass[1], password: userPass[2] }
-}
-
-function decodeBase64(str: string) {
-  if (atob) {
-    const text = atob(str)
-    const length = text.length
-    const bytes = new Uint8Array(length)
-    for (let i = 0; i < length; i++) {
-      bytes[i] = text.charCodeAt(i)
-    }
-    const decoder = new TextDecoder()
-    return decoder.decode(bytes)
-  } else {
-    const { Buffer } = require('buffer')
-    return Buffer.from(str, 'base64').toString()
-  }
 }
 
 export const basicAuth = (options: { username: string; password: string; realm?: string }) => {

--- a/src/utils/buffer.test.ts
+++ b/src/utils/buffer.test.ts
@@ -12,11 +12,15 @@ describe('buffer', () => {
   it('decodeBaes64', async () => {
     expect(await decodeBase64('aG9vb29vb29vbw==')).toBe('hooooooooo')
     expect(await decodeBase64('54KO')).toBe('炎')
+
+    expect(await decodeBase64('abcdedf')).not.toBe('abcdef')
   })
 
   it('sha256', async () => {
     expect(await sha256('hono')).toBe('8b3dc17add91b7e8f0b5109a389927d66001139cd9b03fa7b95f83126e1b2b23')
     expect(await sha256('炎')).toBe('1fddc5a562ee1fbeb4fc6def7d4be4911fcdae4273b02ae3a507b170ba0ea169')
+
+    expect(await sha256('abcdedf')).not.toBe('abcdef')
   })
 
   it('positive', async () => {

--- a/src/utils/buffer.test.ts
+++ b/src/utils/buffer.test.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from './buffer'
+import { timingSafeEqual, sha256, decodeBase64 } from './buffer'
 
 describe('buffer', () => {
   const crypto = global.crypto
@@ -7,6 +7,16 @@ describe('buffer', () => {
   })
   afterAll(() => {
     global.crypto = crypto
+  })
+
+  it('decodeBaes64', async () => {
+    expect(await decodeBase64('aG9vb29vb29vbw==')).toBe('hooooooooo')
+    expect(await decodeBase64('54KO')).toBe('炎')
+  })
+
+  it('sha256', async () => {
+    expect(await sha256('hono')).toBe('8b3dc17add91b7e8f0b5109a389927d66001139cd9b03fa7b95f83126e1b2b23')
+    expect(await sha256('炎')).toBe('1fddc5a562ee1fbeb4fc6def7d4be4911fcdae4273b02ae3a507b170ba0ea169')
   })
 
   it('positive', async () => {
@@ -25,18 +35,8 @@ describe('buffer', () => {
 
   it('negative', async () => {
     expect(await timingSafeEqual('a', 'b')).toBe(false)
-    expect(
-      await timingSafeEqual(
-        'a',
-        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-      )
-    ).toBe(false)
-    expect(
-      await timingSafeEqual(
-        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        'a'
-      )
-    ).toBe(false)
+    expect(await timingSafeEqual('a', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).toBe(false)
+    expect(await timingSafeEqual('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'a')).toBe(false)
     expect(await timingSafeEqual('alpha', 'beta')).toBe(false)
     expect(await timingSafeEqual(false, true)).toBe(false)
     expect(await timingSafeEqual(false, undefined)).toBe(false)

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -19,20 +19,41 @@ export const equal = (a: ArrayBuffer, b: ArrayBuffer) => {
   return true
 }
 
+export const decodeBase64 = (str: string) => {
+  try {
+    const text = atob(str)
+    const length = text.length
+    const bytes = new Uint8Array(length)
+    for (let i = 0; i < length; i++) {
+      bytes[i] = text.charCodeAt(i)
+    }
+    const decoder = new TextDecoder()
+    return decoder.decode(bytes)
+  } catch {
+    const { Buffer } = require('buffer')
+    return Buffer.from(str, 'base64').toString()
+  }
+}
+
+export const sha256 = async (a: string): Promise<string> => {
+  if (crypto && crypto.subtle) {
+    const buffer = await crypto.subtle.digest(
+      {
+        name: 'SHA-256',
+      },
+      new TextEncoder().encode(String(a))
+    )
+    const hash = Array.prototype.map.call(new Uint8Array(buffer), (x) => ('00' + x.toString(16)).slice(-2)).join('')
+    return hash
+  } else {
+    const crypto = await import('crypto')
+    const hash = crypto.createHash('sha256').update(a).digest('hex')
+    return hash
+  }
+}
+
 export const timingSafeEqual = async (a: any, b: any) => {
-  const sa = await crypto.subtle.digest(
-    {
-      name: 'SHA-256',
-    },
-    new TextEncoder().encode(String(a))
-  )
-
-  const sb = await crypto.subtle.digest(
-    {
-      name: 'SHA-256',
-    },
-    new TextEncoder().encode(String(b))
-  )
-
-  return equal(sa, sb) && a === b
+  const sa = await sha256(a)
+  const sb = await sha256(b)
+  return sa === sb && a === b
 }

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -29,9 +29,14 @@ export const decodeBase64 = (str: string) => {
     }
     const decoder = new TextDecoder()
     return decoder.decode(bytes)
-  } catch {
+  } catch {}
+
+  try {
     const { Buffer } = require('buffer')
     return Buffer.from(str, 'base64').toString()
+  } catch (e) {
+    console.error('If you want to do "decodeBase64", polyfill "buffer" module.')
+    throw e
   }
 }
 
@@ -45,10 +50,15 @@ export const sha256 = async (a: string): Promise<string> => {
     )
     const hash = Array.prototype.map.call(new Uint8Array(buffer), (x) => ('00' + x.toString(16)).slice(-2)).join('')
     return hash
-  } else {
+  }
+
+  try {
     const crypto = await import('crypto')
     const hash = crypto.createHash('sha256').update(a).digest('hex')
     return hash
+  } catch (e) {
+    console.error('If you want to do "sha256", polyfill "crypto" module.')
+    throw e
   }
 }
 


### PR DESCRIPTION
Basic auth support Fastly Compute@Edge with polyfills.

Webpack example:

```js
const path = require('path')

module.exports = {
  entry: './index.js',
  target: ['webworker'],
  output: {
    filename: 'index.js',
    path: path.resolve(__dirname, 'bin'),
    libraryTarget: 'this',
  },
  resolve: {
    fallback: {
      buffer: require.resolve('buffer/'),
      crypto: require.resolve('crypto-browserify'),
      stream: require.resolve('stream-browserify'),
      process: require.resolve('process/browser'),
    },
  }
}
```