### PR TITLE
Added type to c.req.param key.

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -6,8 +6,8 @@ type Data = string | ArrayBuffer | ReadableStream
 
 export interface Env {}
 
-export class Context {
-  req: Request
+export class Context<RequestParamKeyType = string> {
+  req: Request<RequestParamKeyType>
   res: Response
   env: Env
   event: FetchEvent
@@ -17,7 +17,7 @@ export class Context {
 
   render: (template: string, params?: object, options?: object) => Promise<Response>
 
-  constructor(req: Request, opts?: { res: Response; env: Env; event: FetchEvent }) {
+  constructor(req: Request<RequestParamKeyType>, opts?: { res: Response; env: Env; event: FetchEvent }) {
     this.req = req
     if (opts) {
       this.res = opts.res

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -116,6 +116,8 @@ export class Hono {
   connect
   */
 
+  all<Path extends string>(arg: Path, ...args: Handler<ParamKeys<Path>>[]) : Hono;
+  all(arg: Handler<never>, ...args: Handler<never>[]): Hono;
   all(arg: string | Handler, ...args: Handler[]): Hono {
     return this.addRoute('all', arg, ...args)
   }

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -8,16 +8,32 @@ import type { Env } from './context'
 const METHOD_NAME_OF_ALL = 'ALL'
 
 declare global {
-  interface Request {
-    param: (key: string) => string
+  interface Request<ParamKeyType = string> {
+    param: (key: ParamKeyType) => string
     query: (key: string) => string
     header: (name: string) => string
     parsedBody: any
   }
 }
 
-export type Handler = (c: Context, next?: Function) => Response | Promise<Response>
+export type Handler<RequestParamKeyType = string> = (
+  c: Context<RequestParamKeyType>,
+  next?: Function
+) => Response | Promise<Response>
 export type MiddlewareHandler = (c: Context, next: Function) => Promise<void>
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type ParamKeyName<NameWithPattern> = NameWithPattern extends `${infer Name}{${infer _Pattern}`
+  ? Name
+  : NameWithPattern
+
+type ParamKey<Component> = Component extends `:${infer NameWithPattern}`
+  ? ParamKeyName<NameWithPattern>
+  : never
+
+type ParamKeys<Path> = Path extends `${infer Component}/${infer Rest}`
+  ? ParamKey<Component> | ParamKeys<Rest>
+  : ParamKey<Path>
 
 export class Router<T> {
   node: Node<T>
@@ -47,24 +63,38 @@ export class Hono {
   }
 
   /* HTTP METHODS */
+  get<Path extends string>(arg: Path, ...args: Handler<ParamKeys<Path>>[]) : Hono;
+  get(arg: Handler<never>, ...args: Handler<never>[]): Hono;
   get(arg: string | Handler, ...args: Handler[]): Hono {
     return this.addRoute('get', arg, ...args)
   }
+  post<Path extends string>(arg: Path, ...args: Handler<ParamKeys<Path>>[]) : Hono;
+  post(arg: Handler, ...args: Handler[]): Hono;
   post(arg: string | Handler, ...args: Handler[]): Hono {
     return this.addRoute('post', arg, ...args)
   }
+  put<Path extends string>(arg: Path, ...args: Handler<ParamKeys<Path>>[]) : Hono;
+  put(arg: Handler, ...args: Handler[]): Hono;
   put(arg: string | Handler, ...args: Handler[]): Hono {
     return this.addRoute('put', arg, ...args)
   }
+  head<Path extends string>(arg: Path, ...args: Handler<ParamKeys<Path>>[]) : Hono;
+  head(arg: Handler, ...args: Handler[]): Hono;
   head(arg: string | Handler, ...args: Handler[]): Hono {
     return this.addRoute('head', arg, ...args)
   }
+  delete<Path extends string>(arg: Path, ...args: Handler<ParamKeys<Path>>[]) : Hono;
+  delete(arg: Handler, ...args: Handler[]): Hono;
   delete(arg: string | Handler, ...args: Handler[]): Hono {
     return this.addRoute('delete', arg, ...args)
   }
+  options<Path extends string>(arg: Path, ...args: Handler<ParamKeys<Path>>[]) : Hono;
+  options(arg: Handler, ...args: Handler[]): Hono;
   options(arg: string | Handler, ...args: Handler[]): Hono {
     return this.addRoute('options', arg, ...args)
   }
+  patch<Path extends string>(arg: Path, ...args: Handler<ParamKeys<Path>>[]) : Hono;
+  patch(arg: Handler, ...args: Handler[]): Hono;
   patch(arg: string | Handler, ...args: Handler[]): Hono {
     return this.addRoute('patch', arg, ...args)
   }


### PR DESCRIPTION
Hi,

Thank you for publishing such a good product.

This PR adds the ability to complete the type of `c.req.param`.

I think this is a nice feature, but it also makes type definitions more complex, so I think it is reasonable to decide not to adopt it.

## Pros

We can get support from the editor for the type of c.req.param. Also, if there is no possibility of a value being returned from c.req.param, the parameter type will be set to `never` and cannot be specified.

https://user-images.githubusercontent.com/30598/153787066-92e7f97b-32e9-4387-add5-166b2cf302c9.mov


<img width="816" alt="image" src="https://user-images.githubusercontent.com/30598/153786609-74ecf20f-9bf9-4615-b251-9140b27b9f61.png">

<img width="856" alt="image" src="https://user-images.githubusercontent.com/30598/153786684-b8e45d7b-2843-4665-b3a2-59529a92665c.png">

<img width="818" alt="image" src="https://user-images.githubusercontent.com/30598/153786740-78bb99e4-c03b-42c8-9a79-d5d4b186a25d.png">

<img width="986" alt="image" src="https://user-images.githubusercontent.com/30598/153786761-2233e5da-ba4b-4e21-89fd-c4140a144b4a.png">



### Cons

The simplicity of the type display will be lost.
The following image is before the PR was applied. For those who are not used to reading conditional type specifications, this may be easier to read.

<img width="733" alt="image" src="https://user-images.githubusercontent.com/30598/153787263-9cba0364-51d9-4a49-a716-fa640c456c2e.png">
