### PR TITLE
feat: nested route

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Below is a demonstration to create an application of Cloudflare Workers with Hon
 
 Now, the named path parameter has types.
 
-![Demo](https://user-images.githubusercontent.com/10682/154018316-50456d41-eefd-4ec9-b444-2d6f22def99d.png)
+![Demo](https://user-images.githubusercontent.com/10682/154179671-9e491597-6778-44ac-a8e6-4483d7ad5393.png)
 
 ## Install
 
@@ -57,7 +57,7 @@ npm install hono
 
 ## Methods
 
-Instance of `Hono` has these methods:
+An instance of `Hono` has these methods:
 
 - app.**HTTP_METHOD**(path, handler)
 - app.**all**(path, handler)
@@ -108,14 +108,17 @@ app.get('/post/:date{[0-9]+}/:title{[a-z]+}', (c) => {
   ...
 ```
 
-### Chained Route
+### Nested route
 
 ```js
-app
-  .route('/api/book')
-    .get(() => {...})
-    .post(() => {...})
-    .put(() => {...})
+const book = app.route('/book')
+book.get('/', (c) => c.text('List Books')) // => GET /book
+book.get('/:id', (c) => {
+  // => GET /book/:id
+  const id = c.req.param('id')
+  return c.text('Get Book: ' + id)
+})
+book.post('/', (c) => c.text('Create Book')) // => POST /book
 ```
 
 ### Custom 404 Response
@@ -163,15 +166,7 @@ const app = new Hono()
 
 app.use('*', poweredBy())
 app.use('*', logger())
-app.use(
-  '/auth/*',
-  basicAuth({
-    username: 'hono',
-    password: 'acoolproject',
-  })
-)
-
-...
+app.use('/auth/*', basicAuth({ username: 'hono', password: 'acoolproject' }))
 ```
 
 Available builtin middleware are listed on [src/middleware](https://github.com/yusukebe/hono/tree/master/src/middleware).

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -53,6 +53,16 @@ app.get('/entry/:id', (c) => {
   const id = c.req.param('id')
   return c.text(`Your ID is ${id}`)
 })
+
+// Nested route
+const book = app.route('/book')
+book.get('/', (c) => c.text('List Books'))
+book.get('/:id', (c) => {
+  const id = c.req.param('id')
+  return c.text('Get Book: ' + id)
+})
+book.post('/', (c) => c.text('Create Book'))
+
 // Redirect
 app.get('/redirect', (c) => c.redirect('/'))
 // Authentication required

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -1,4 +1,4 @@
-import { splitPath, getPattern, getPathFromURL, isAbsoluteURL } from './url'
+import { splitPath, getPattern, getPathFromURL, isAbsoluteURL, mergePath } from './url'
 
 describe('url', () => {
   it('splitPath', () => {
@@ -68,6 +68,26 @@ describe('url', () => {
       expect(isAbsoluteURL('/')).not.toBeTruthy()
       expect(isAbsoluteURL('/location')).not.toBeTruthy()
       expect(isAbsoluteURL('')).not.toBeTruthy()
+    })
+  })
+
+  describe('mergePath', () => {
+    it('mergePath', () => {
+      expect(mergePath('/book', '/')).toBe('/book')
+      expect(mergePath('/book/', '/')).toBe('/book/')
+      expect(mergePath('/book', '/hey')).toBe('/book/hey')
+      expect(mergePath('/book/', '/hey')).toBe('/book/hey')
+      expect(mergePath('/book', '/hey/')).toBe('/book/hey/')
+      expect(mergePath('/book/', '/hey/')).toBe('/book/hey/')
+      expect(mergePath('/book', 'hey', 'say')).toBe('/book/hey/say')
+      expect(mergePath('/book', '/hey/', '/say/')).toBe('/book/hey/say/')
+      expect(mergePath('/book', '/hey/', '/say/', '/')).toBe('/book/hey/say/')
+
+      expect(mergePath('book', '/')).toBe('/book')
+      expect(mergePath('book/', '/')).toBe('/book/')
+      expect(mergePath('book', '/hey')).toBe('/book/hey')
+      expect(mergePath('book', 'hey')).toBe('/book/hey')
+      expect(mergePath('book', 'hey/')).toBe('/book/hey/')
     })
   })
 })

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -48,3 +48,30 @@ export const isAbsoluteURL = (url: string): boolean => {
   }
   return false
 }
+
+export const mergePath = (...paths: string[]): string => {
+  let p: string = ''
+  let endsWithSlash = false
+
+  for (let path of paths) {
+    /* ['/hey/','/say'] => ['/hey', '/say'] */
+    if (p.endsWith('/')) {
+      p = p.slice(0, -1)
+      endsWithSlash = true
+    }
+
+    /* ['/hey','say'] => ['/hey', '/say'] */
+    if (!path.startsWith('/')) {
+      path = `/${path}`
+    }
+
+    /* ['/hey/', '/'] => `/hey/` */
+    if (path === '/' && endsWithSlash) {
+      p = `${p}/`
+    } else if (path !== '/') {
+      p = `${p}${path}`
+    }
+  }
+
+  return p
+}

--- a/test/hono.test.ts
+++ b/test/hono.test.ts
@@ -123,46 +123,46 @@ describe('Routing', () => {
     expect(await res.text()).toBe('delete /')
   })
 
-  it('Chained route', async () => {
-    app
-      .route('/route')
-      .get(() => new Response('get /route'))
-      .post(() => new Response('post /route'))
-      .put(() => new Response('put /route'))
-    let req = new Request('http://localhost/route', { method: 'GET' })
+  it('Nested route', async () => {
+    const book = app.route('/book')
+    book.get('/', (c) => c.text('get /book'))
+    book.get('/:id', (c) => {
+      return c.text('get /book/' + c.req.param('id'))
+    })
+    book.post('/', (c) => c.text('post /book'))
+
+    const user = app.route('/user')
+    user.get('/login', (c) => c.text('get /user/login'))
+    user.post('/regist', (c) => c.text('post /user/regist'))
+
+    let req = new Request('http://localhost/book', { method: 'GET' })
     let res = await app.dispatch(req)
     expect(res.status).toBe(200)
-    expect(await res.text()).toBe('get /route')
+    expect(await res.text()).toBe('get /book')
 
-    req = new Request('http://localhost/route', { method: 'POST' })
+    req = new Request('http://localhost/book/123', { method: 'GET' })
     res = await app.dispatch(req)
     expect(res.status).toBe(200)
-    expect(await res.text()).toBe('post /route')
+    expect(await res.text()).toBe('get /book/123')
 
-    req = new Request('http://localhost/route', { method: 'DELETE' })
+    req = new Request('http://localhost/book', { method: 'POST' })
+    res = await app.dispatch(req)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('post /book')
+
+    req = new Request('http://localhost/book/', { method: 'GET' })
     res = await app.dispatch(req)
     expect(res.status).toBe(404)
-  })
 
-  it('Chained route without route method', async () => {
-    app
-      .get('/without-route', () => new Response('get /without-route'))
-      .post(() => new Response('post /without-route'))
-      .put(() => new Response('put /without-route'))
-
-    let req = new Request('http://localhost/without-route', { method: 'GET' })
-    let res = await app.dispatch(req)
-    expect(res.status).toBe(200)
-    expect(await res.text()).toBe('get /without-route')
-
-    req = new Request('http://localhost/without-route', { method: 'POST' })
+    req = new Request('http://localhost/user/login', { method: 'GET' })
     res = await app.dispatch(req)
     expect(res.status).toBe(200)
-    expect(await res.text()).toBe('post /without-route')
+    expect(await res.text()).toBe('get /user/login')
 
-    req = new Request('http://localhost/without-route', { method: 'DELETE' })
+    req = new Request('http://localhost/user/regist', { method: 'POST' })
     res = await app.dispatch(req)
-    expect(res.status).toBe(404)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('post /user/regist')
   })
 })
 


### PR DESCRIPTION
# BREAKING CHANGES!!!

`app.route` is changed:

**Chained route** is obsolete:

```
app.route('/')
  .get((c) => c.text('get /'))
// ^^^ Not working now!!
```

Now, `app.route` enables **nested route**:

```
const book = app.route('/book')
book.get('/', (c) => c.text('List books')) // => GET /book
book.get('/:id', (c) => {
  return c.text('Get Book: ' + c.req.param('id'))) // => GET /book/:id
})
```