### PR TITLE
Introduce RegExpRouter

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -1,16 +1,6 @@
 import type { Pattern } from './utils/url'
 import { splitPath, getPattern } from './utils/url'
-
-export const METHOD_NAME_OF_ALL = 'ALL'
-
-export class Result<T> {
-  handler: T
-  params: Record<string, string>
-  constructor(handler: T, params: Record<string, string>) {
-    this.handler = handler
-    this.params = params
-  }
-}
+import { Result, METHOD_NAME_OF_ALL } from './router'
 
 const noRoute = (): null => {
   return null

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,15 @@
+export const METHOD_NAME_OF_ALL = 'ALL'
+
+export abstract class Router<T> {
+  abstract add(method: string, path: string, handler: T): void
+  abstract match(method: string, path: string): Result<T> | null
+}
+
+export class Result<T> {
+  handler: T
+  params: Record<string, string>
+  constructor(handler: T, params: Record<string, string>) {
+    this.handler = handler
+    this.params = params
+  }
+}

--- a/src/router/reg-exp-router/index.ts
+++ b/src/router/reg-exp-router/index.ts
@@ -1,0 +1,1 @@
+export { RegExpRouter } from './router'

--- a/src/router/reg-exp-router/node.ts
+++ b/src/router/reg-exp-router/node.ts
@@ -1,0 +1,110 @@
+const LABEL_REG_EXP_STR = '[^/]+'
+const ONLY_WILDCARD_REG_EXP_STR = '.*'
+const TAIL_WILDCARD_REG_EXP_STR = '(?:|/.*)'
+
+export interface ParamMap {
+  [key: string]: number
+}
+export interface Context {
+  varIndex: number
+}
+
+/**
+ * Sort order:
+ * 1. literal
+ * 2. special pattern (e.g. :label{[0-9]+})
+ * 3. common label pattern (e.g. :label)
+ * 4. wildcard
+ */
+function compareKey(a: string, b: string): number {
+  if (a.length === 1) {
+    return b.length === 1 ? (a < b ? -1 : 1) : -1
+  }
+  if (b.length === 1) {
+    return 1
+  }
+
+  // wildcard
+  if (a === ONLY_WILDCARD_REG_EXP_STR || a === TAIL_WILDCARD_REG_EXP_STR) {
+    return 1
+  } else if (b === ONLY_WILDCARD_REG_EXP_STR || b === TAIL_WILDCARD_REG_EXP_STR) {
+    return -1
+  }
+
+  // label
+  if (a === LABEL_REG_EXP_STR) {
+    return 1
+  } else if (b === LABEL_REG_EXP_STR) {
+    return -1
+  }
+
+  return a.length === b.length ? (a < b ? -1 : 1) : b.length - a.length
+}
+
+export class Node {
+  index?: number
+  varIndex?: number
+  children: {
+    [key: string]: Node
+  } = {}
+
+  insert(tokens: readonly string[], index: number, paramMap: ParamMap, context: Context): void {
+    if (tokens.length === 0) {
+      this.index = index
+      return
+    }
+
+    const [token, ...restTokens] = tokens
+    const pattern =
+      token === '*'
+        ? restTokens.length === 0
+          ? ['', '', ONLY_WILDCARD_REG_EXP_STR] // '*' matches to all the trailing paths
+          : ['', '', LABEL_REG_EXP_STR]
+        : token === '/*'
+        ? ['', '', TAIL_WILDCARD_REG_EXP_STR] // '/path/to/*' is /\/path\/to(?:|/.*)$
+        : token.match(/^\:([^\{\}]+)(?:\{(.+)\})?$/)
+
+    let node
+    if (pattern) {
+      const name = pattern[1]
+      const regexpStr = pattern[2] || LABEL_REG_EXP_STR
+
+      node = this.children[regexpStr]
+      if (!node) {
+        node = this.children[regexpStr] = new Node()
+        if (name !== '') {
+          node.varIndex = context.varIndex++
+        }
+      }
+      if (name !== '') {
+        paramMap[name] = node.varIndex
+      }
+    } else {
+      node = this.children[token] ||= new Node()
+    }
+
+    node.insert(restTokens, index, paramMap, context)
+  }
+
+  buildRegExpStr(): string {
+    const strList = Object.keys(this.children)
+      .sort(compareKey)
+      .map((k) => {
+        const c = this.children[k]
+        return (typeof c.varIndex === 'number' ? `(${k})@${c.varIndex}` : k) + c.buildRegExpStr()
+      })
+
+    if (typeof this.index === 'number') {
+      strList.push(`#${this.index}`)
+    }
+
+    if (strList.length === 0) {
+      return ''
+    }
+    if (strList.length === 1) {
+      return strList[0]
+    }
+
+    return '(?:' + strList.join('|') + ')'
+  }
+}

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -1,0 +1,70 @@
+import { RegExpRouter } from './router'
+
+describe('Basic Usage', () => {
+  const router = new RegExpRouter<string>()
+
+  router.add('GET', '/hello', 'get hello')
+  router.add('POST', '/hello', 'post hello')
+
+  it('get, post hello', async () => {
+    let res = router.match('GET', '/hello')
+    expect(res).not.toBeNull()
+    expect(res.handler).toBe('get hello')
+
+    res = router.match('POST', '/hello')
+    expect(res).not.toBeNull()
+    expect(res.handler).toBe('post hello')
+
+    res = router.match('PUT', '/hello')
+    expect(res).toBeNull()
+
+    res = router.match('GET', '/')
+    expect(res).toBeNull()
+  })
+})
+
+describe('Complex', () => {
+  let router: RegExpRouter<string>
+  beforeEach(() => {
+    router = new RegExpRouter<string>()
+  })
+
+  it('Named Param', async () => {
+    router.add('GET', '/entry/:id', 'get entry')
+    const res = router.match('GET', '/entry/123')
+    expect(res).not.toBeNull()
+    expect(res.handler).toBe('get entry')
+    expect(res.params['id']).toBe('123')
+  })
+
+  it('Wildcard', async () => {
+    router.add('GET', '/wild/*/card', 'get wildcard')
+    const res = router.match('GET', '/wild/xxx/card')
+    expect(res).not.toBeNull()
+    expect(res.handler).toBe('get wildcard')
+  })
+
+  it('Default', async () => {
+    router.add('GET', '/api/abc', 'get api')
+    router.add('GET', '/api/*', 'fallback')
+    let res = router.match('GET', '/api/abc')
+    expect(res).not.toBeNull()
+    expect(res.handler).toBe('get api')
+    res = router.match('GET', '/api/def')
+    expect(res).not.toBeNull()
+    expect(res.handler).toBe('fallback')
+  })
+
+  it('Regexp', async () => {
+    router.add('GET', '/post/:date{[0-9]+}/:title{[a-z]+}', 'get post')
+    let res = router.match('GET', '/post/20210101/hello')
+    expect(res).not.toBeNull()
+    expect(res.handler).toBe('get post')
+    expect(res.params['date']).toBe('20210101')
+    expect(res.params['title']).toBe('hello')
+    res = router.match('GET', '/post/onetwothree')
+    expect(res).toBeNull()
+    res = router.match('GET', '/post/123/123')
+    expect(res).toBeNull()
+  })
+})

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -1,0 +1,85 @@
+import { Router, Result, METHOD_NAME_OF_ALL } from '../../router'
+import type { ParamMap, ReplacementMap } from './trie'
+import { Trie } from './trie'
+
+type Route<T> = [string, T]
+type HandlerData<T> = [T, ParamMap]
+type Matcher<T> = [RegExp, ReplacementMap, HandlerData<T>[]]
+
+export class RegExpRouter<T> extends Router<T> {
+  routes?: {
+    [method: string]: Route<T>[]
+  } = {}
+
+  matchers?: {
+    [method: string]: Matcher<T>
+  } = null
+
+  add(method: string, path: string, handler: T) {
+    this.routes[method] ||= []
+    this.routes[method].push([path, handler])
+  }
+
+  match(method: string, path: string): Result<T> | null {
+    if (!this.matchers) {
+      this.buildAllMatchers()
+    }
+
+    const matcher = this.matchers[method] || this.matchers[METHOD_NAME_OF_ALL]
+    if (!matcher) {
+      return null
+    }
+
+    const [regexp, replacementMap, handlers] = matcher
+    const match = path.match(regexp)
+    if (!match) {
+      return null
+    }
+    const index = match.indexOf('', 1)
+    const [handler, paramMap] = handlers[replacementMap[index]]
+    const params: { [key: string]: string } = {}
+    const keys = Object.keys(paramMap)
+    for (let i = 0; i < keys.length; i++) {
+      params[keys[i]] = match[paramMap[keys[i]]]
+    }
+    return new Result(handler, params)
+  }
+
+  private buildAllMatchers() {
+    this.matchers ||= {}
+
+    Object.keys(this.routes).forEach((method) => {
+      this.buildMatcher(method)
+    })
+
+    delete this.routes // to reduce memory usage
+  }
+
+  private buildMatcher(method: string) {
+    this.matchers ||= {}
+
+    const trie = new Trie()
+    const handlers: HandlerData<T>[] = []
+
+    const targetMethods = [method]
+    if (method !== METHOD_NAME_OF_ALL) {
+      targetMethods.unshift(METHOD_NAME_OF_ALL)
+    }
+    const routes = targetMethods.flatMap((method) => this.routes[method] || [])
+
+    for (let i = 0; i < routes.length; i++) {
+      const paramMap = trie.insert(routes[i][0], i)
+      handlers[i] = [routes[i][1], paramMap]
+    }
+
+    const [regexp, indexReplacementMap, paramReplacementMap] = trie.buildRegExp()
+    for (let i = 0; i < handlers.length; i++) {
+      const paramMap = handlers[i][1]
+      Object.keys(paramMap).forEach((k) => {
+        paramMap[k] = paramReplacementMap[paramMap[k]]
+      })
+    }
+
+    this.matchers[method] = [new RegExp(regexp), indexReplacementMap, handlers]
+  }
+}

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -16,6 +16,10 @@ export class RegExpRouter<T> extends Router<T> {
   } = null
 
   add(method: string, path: string, handler: T) {
+    if (!this.routes) {
+      throw new Error('Can not add a route since the matcher is already built.')
+    }
+
     this.routes[method] ||= []
     this.routes[method].push([path, handler])
   }

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1,7 +1,7 @@
-import { Router } from '../src/hono'
+import { TrieRouter } from '../src/hono'
 
 describe('Basic Usage', () => {
-  const router = new Router<string>()
+  const router = new TrieRouter<string>()
 
   router.add('GET', '/hello', 'get hello')
   router.add('POST', '/hello', 'post hello')
@@ -24,7 +24,7 @@ describe('Basic Usage', () => {
 })
 
 describe('Complex', () => {
-  const router = new Router<string>()
+  const router = new TrieRouter<string>()
 
   it('Named Param', async () => {
     router.add('GET', '/entry/:id', 'get entry')


### PR DESCRIPTION
Hi,

I tried to improve the performance of the router using a different strategy.

### Strategy

All the routes into one RegExp object.

* /help
* /:user_id/followees
* /:user_id/followers
* /:user_id/posts
* /:user_id/posts/:post_id
* /:user_id/posts/:post_id/likes

into `^/(?:help$()|([^/]+)/(?:followe(?:es$()|rs$())|posts(?:/([^/]+)(?:/likes$()|$())|$())))`

It will be a large regular expression, but since common prefixes can be grouped together by trie, I think it will grow slowly in the general case.
Also, the return value of `match` will be larger in proportion to the number of routes, but it will be an array where most of the elements are `undefined`, so I think it is still an acceptable size in the general case.

#### Existing modules adopting the same strategy

The following Perl modules use large regular expression objects for high performance.

* [Router::Boom](https://github.com/tokuhirom/Router-Boom)
* [Router::Assemble](https://github.com/sixapart/Router-Assemble)


### Benchmark

```
hono x 410,442 ops/sec ±5.62% (72 runs sampled)
hono with RegExpRouter x 460,937 ops/sec ±6.52% (65 runs sampled)
itty-router x 73,523 ops/sec ±3.63% (81 runs sampled)
sunder x 131,994 ops/sec ±0.80% (84 runs sampled)
worktop x 81,120 ops/sec ±4.16% (82 runs sampled)
Fastest is hono with RegExpRouter
```

### Compatibility

I ran a test by changing it to use RegExpRouter by default and got green, so I believe it is compatible enough.
https://github.com/usualoma/hono/compare/regexp-router..regexp-router-as-default

#### Known differences

* The current router can include capture in `{}` notation (e.g. `/:action{(update|delete)}`), but RegExpRouter can't.  We need to use `(?:...)` instead of `(...)`.
* The current router can `add` route after call `match`, but RegExpRouter can't.
* The current router can not handle multiple capture in same position (e.g. `/path/to/:decimal{[0-9]+}`, `/path/to/:hexadecimal{0x[0-9A-F]+}`), but RegExpRouter can.