### PR TITLE
Make ParamMap Array<[key, value]>.

### DIFF
--- a/src/router/reg-exp-router/node.ts
+++ b/src/router/reg-exp-router/node.ts
@@ -2,9 +2,7 @@ const LABEL_REG_EXP_STR = '[^/]+'
 const ONLY_WILDCARD_REG_EXP_STR = '.*'
 const TAIL_WILDCARD_REG_EXP_STR = '(?:|/.*)'
 
-export interface ParamMap {
-  [key: string]: number
-}
+export type ParamMap = Array<[string, number]>
 export interface Context {
   varIndex: number
 }
@@ -77,7 +75,7 @@ export class Node {
         }
       }
       if (name !== '') {
-        paramMap[name] = node.varIndex
+        paramMap.push([name, node.varIndex])
       }
     } else {
       node = this.children[token] ||= new Node()

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -52,9 +52,8 @@ export class RegExpRouter<T> extends Router<T> {
     const index = match.indexOf('', 1)
     const [handler, paramMap] = handlers[replacementMap[index]]
     const params: { [key: string]: string } = {}
-    const keys = Object.keys(paramMap)
-    for (let i = 0; i < keys.length; i++) {
-      params[keys[i]] = match[paramMap[keys[i]]]
+    for (let i = 0; i < paramMap.length; i++) {
+      params[paramMap[i][0]] = match[paramMap[i][1]]
     }
     return new Result(handler, params)
   }
@@ -87,7 +86,7 @@ export class RegExpRouter<T> extends Router<T> {
     }
 
     if (routes.length === 1 && routes[0][0] === '*') {
-      this.matchers[method] = [true, null, [[routes[0][1], {}]]]
+      this.matchers[method] = [true, null, [[routes[0][1], []]]]
       return
     }
 
@@ -97,7 +96,7 @@ export class RegExpRouter<T> extends Router<T> {
         ? routes[0][0].replace(/\/\*$/, '(?:$|/)') // /path/to/* => /path/to(?:$|/)
         : `${routes[0][0]}$` // /path/to/action => /path/to/action$
       const regExpStr = `^${tmp.replace(/\*/g, '[^/]+')}` // /prefix/*/path/to => /prefix/[^/]+/path/to
-      this.matchers[method] = [new RegExp(regExpStr), null, [[routes[0][1], {}]]]
+      this.matchers[method] = [new RegExp(regExpStr), null, [[routes[0][1], []]]]
       return
     }
 
@@ -109,9 +108,9 @@ export class RegExpRouter<T> extends Router<T> {
     const [regexp, indexReplacementMap, paramReplacementMap] = trie.buildRegExp()
     for (let i = 0; i < handlers.length; i++) {
       const paramMap = handlers[i][1]
-      Object.keys(paramMap).forEach((k) => {
-        paramMap[k] = paramReplacementMap[paramMap[k]]
-      })
+      for (let i = 0; i < paramMap.length; i++) {
+        paramMap[i][1] = paramReplacementMap[paramMap[i][1]]
+      }
     }
 
     this.matchers[method] = [new RegExp(regexp), indexReplacementMap, handlers]

--- a/src/router/reg-exp-router/trie.ts
+++ b/src/router/reg-exp-router/trie.ts
@@ -9,7 +9,7 @@ export class Trie {
   root: Node = new Node()
 
   insert(path: string, index: number): ParamMap {
-    const paramMap = {}
+    const paramMap: ParamMap = []
 
     /**
      *  - pattern (:label, :label{0-9]+}, ...)


### PR DESCRIPTION
In this PR, I will add a very small optimization to RegExpRouter.

It turns out that iterating through the results of Object.keys is little bit expensive, so I change ParamMap to a list of keys and values (a.k.a Association List).

https://gist.github.com/usualoma/6d22fdb1b64e7ae8f4d6fe2d204b9208

I don't think this optimization will make any visible difference to the router benchmarks.

### FYI

I also tried optimize by using lastIndexOf() instead of indexOf(), but failed. Because lastIndexOf() is slow.
https://blog.taaas.jp/tips/v8lastindexof/

