### PR TITLE
feat: `app.notFound()` and `app.onError()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ An instance of `Hono` has these methods.
 - app.**all**(path, handler)
 - app.**route**(path)
 - app.**use**(path, middleware)
+- app.**notFound**(handler)
+- app.**onError**(err, handler)
 - app.**fire**()
 - app.**fetch**(request, env, event)
 
@@ -126,10 +128,10 @@ book.post('/', (c) => c.text('Create Book')) // POST /book
 
 ### no strict
 
-If `strict` is set `false`, `/hello`and`/hello/` are treated the same. Default is `true`.
+If `strict` is set false, `/hello`and`/hello/` are treated the same.
 
 ```js
-const app = new Hono({ strict: false })
+const app = new Hono({ strict: false }) // Default is true
 
 app.get('/hello', (c) => c.text('/hello or /hello/'))
 ```
@@ -188,6 +190,29 @@ app.use('/message/*', async (c, next) => {
 app.get('/message/hello', (c) => c.text('Hello Middleware!'))
 ```
 
+## Error
+
+### Not Found
+
+`app.notFound` for customizing Not Found Response.
+
+```js
+app.notFound((c) => {
+  return c.text('Custom 404 Message', 404)
+})
+```
+
+### Error Handling
+
+`app.onError` handle the error and return the customized Response.
+
+```js
+app.onError((err, c) => {
+  console.error(`${err}`)
+  return c.text('Custom Error Message', 500)
+})
+```
+
 ## Context
 
 To handle Request and Reponse, you can use Context object.
@@ -224,10 +249,12 @@ app.get('/entry/:id', (c) => {
 
 ```js
 app.get('/welcome', (c) => {
+  // Set headers
   c.header('X-Message', 'Hello!')
   c.header('Content-Type', 'text/plain')
+  // Set HTTP status code
   c.status(201)
-
+  // Return the response body
   return c.body('Thank you for comming')
 })
 ```
@@ -278,7 +305,7 @@ app.get('/', (c) => {
 
 ### c.notFound()
 
-Return the default `404 Not Found` Response.
+Return the `404 Not Found` Response.
 
 ```js
 app.get('/notfound', (c) => {
@@ -327,26 +354,6 @@ app.get('*', async c => {
 })
 ```
 
-## Not Found
-
-You can write the default `404 Not Found` Response.
-
-```js
-app.notFound = (c) => {
-  return c.text('This is default 404 Not Found', 404)
-}
-```
-
-## Error handling
-
-You can handle errors in your way.
-
-```js
-app.onError = (err, c) => {
-  return c.text(`This is error message: ${err.mssage}`, 500)
-}
-```
-
 ## fire
 
 `app.fire()` do this.
@@ -359,7 +366,7 @@ addEventListener('fetch', (event) => {
 
 ## fetch
 
-`app.fetch()` is for Cloudflare Module Worker syntax.
+`app.fetch` for Cloudflare Module Worker syntax.
 
 ```js
 export default {

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -33,14 +33,15 @@ app.use('*', async (c, next) => {
   await c.header('X-Response-Time', `${ms}ms`)
 })
 
-// Handle error
-app.use('*', async (c, next) => {
-  try {
-    await next()
-  } catch (err) {
-    console.error(`${err}`)
-    c.res = c.text('Custom Error Message', 500)
-  }
+// Custom Not Found Message
+app.notFound((c) => {
+  return c.text('Custom 404 Not Found', 404)
+})
+
+// Error handling
+app.onError((err, c) => {
+  console.error(`${err}`)
+  return c.text('Custom Error Message', 500)
 })
 
 // Routing

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,7 +1,8 @@
 import { Context } from './context'
+import type { ErrorHandler } from './hono'
 
 // Based on the code in the MIT licensed `koa-compose` package.
-export const compose = <T>(middleware: Function[], onError?: Function) => {
+export const compose = <T>(middleware: Function[], onError?: ErrorHandler) => {
   return function (context: T, next?: Function) {
     let index = -1
     return dispatch(0)

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -16,12 +16,6 @@ describe('GET Request', () => {
     return c.html('<h1>Hono!!!</h1>')
   })
 
-  app.notFound = () => {
-    return new Response('not found', {
-      status: 404,
-    })
-  }
-
   it('GET /hello is ok', async () => {
     const req = new Request('http://localhost/hello')
     const res = await app.dispatch(req)
@@ -266,12 +260,12 @@ describe('Middleware', () => {
   })
 })
 
-describe('404 Not Found', () => {
+describe('Not Found', () => {
   const app = new Hono()
 
-  app.notFound = (c) => {
+  app.notFound((c) => {
     return c.text('Custom 404 Not Found', 404)
-  }
+  })
 
   app.get('/hello', (c) => {
     return c.text('hello')
@@ -320,23 +314,23 @@ describe('Error handle', () => {
     throw new Error('This is Middleware Error')
   })
 
-  app.onError = (err, c) => {
-    c.header('debug', err.message)
+  app.onError((err, c) => {
+    c.header('x-debug', err.message)
     return c.text('Custom Error Message', 500)
-  }
+  })
 
   it('Custom Error Message', async () => {
     let req = new Request('https://example.com/error')
     let res = await app.dispatch(req)
     expect(res.status).toBe(500)
     expect(await res.text()).toBe('Custom Error Message')
-    expect(res.headers.get('debug')).toBe('This is Error')
+    expect(res.headers.get('x-debug')).toBe('This is Error')
 
     req = new Request('https://example.com/error-middleware')
     res = await app.dispatch(req)
     expect(res.status).toBe(500)
     expect(await res.text()).toBe('Custom Error Message')
-    expect(res.headers.get('debug')).toBe('This is Middleware Error')
+    expect(res.headers.get('x-debug')).toBe('This is Middleware Error')
   })
 })
 


### PR DESCRIPTION
# BREAKING CHANGES

`app.notFound` and `app.onError` are changed:

```js
// Custom Not Found Response
app.notFound((c) => c.text('404', 404))

// Handle Error and return custom Error Response
app.onError((err, c) => {
  console.error(`${err}`)
  return c.text('500', 500)
})
```