### PR TITLE
Optimize RegExpRouter

### DIFF
--- a/src/router/reg-exp-router/node.ts
+++ b/src/router/reg-exp-router/node.ts
@@ -42,9 +42,7 @@ function compareKey(a: string, b: string): number {
 export class Node {
   index?: number
   varIndex?: number
-  children: {
-    [key: string]: Node
-  } = {}
+  children: Record<string, Node> = {}
 
   insert(tokens: readonly string[], index: number, paramMap: ParamMap, context: Context): void {
     if (tokens.length === 0) {

--- a/src/router/reg-exp-router/router.test.ts
+++ b/src/router/reg-exp-router/router.test.ts
@@ -1,4 +1,5 @@
 import { RegExpRouter } from './router'
+import { METHOD_NAME_OF_ALL } from '../../router'
 
 describe('Basic Usage', () => {
   const router = new RegExpRouter<string>()
@@ -66,5 +67,31 @@ describe('Complex', () => {
     expect(res).toBeNull()
     res = router.match('GET', '/post/123/123')
     expect(res).toBeNull()
+  })
+})
+
+describe('Optimization for METHOD_NAME_OF_ALL', () => {
+  let router: RegExpRouter<string>
+  beforeEach(() => {
+    router = new RegExpRouter<string>()
+  })
+
+  it('Apply to all requests', async () => {
+    router.add(METHOD_NAME_OF_ALL, '*', 'OK')
+    const res = router.match('GET', '/entry/123')
+    expect(res).not.toBeNull()
+    expect(res.handler).toBe('OK')
+    expect(res.params).toMatchObject({})
+  })
+
+  it('Apply to all requests under a specific path', async () => {
+    router.add(METHOD_NAME_OF_ALL, '/path/to/*', 'OK')
+    let res = router.match('GET', '/entry/123')
+    expect(res).toBeNull()
+
+    res = router.match('GET', '/path/to/entry/123')
+    expect(res).not.toBeNull()
+    expect(res.handler).toBe('OK')
+    expect(res.params).toMatchObject({})
   })
 })

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -1,14 +1,16 @@
 import { Router, Result, METHOD_NAME_OF_ALL } from '../../router'
-import type { ParamMap, ReplacementMap } from './trie'
+import type { ParamMap } from './trie'
 import { Trie } from './trie'
 
 type Route<T> = [string, T]
-type HandlerData<T> = [T, ParamMap]
-type Matcher<T> = [RegExp | true, ReplacementMap, HandlerData<T>[]]
+type HandlerData<T> = [T, ParamMap | null]
+type Matcher<T> = [RegExp, HandlerData<T>[]]
+
+const regExpMatchAll = new RegExp('')
+const emptyParam = {}
 
 export class RegExpRouter<T> extends Router<T> {
   routes?: Record<string, Route<T>[]> = {}
-  matchers?: Record<string, Matcher<T> | null> = null
 
   add(method: string, path: string, handler: T) {
     if (!this.routes) {
@@ -20,52 +22,64 @@ export class RegExpRouter<T> extends Router<T> {
   }
 
   match(method: string, path: string): Result<T> | null {
-    if (!this.matchers) {
-      this.buildAllMatchers()
+    const matchers = this.buildAllMatchers()
+
+    let match: typeof this.match
+
+    // Optimization for middleware
+    const methods = Object.keys(matchers)
+    if (methods.length === 1 && methods[0] === METHOD_NAME_OF_ALL) {
+      const [regexp, handlers] = matchers[METHOD_NAME_OF_ALL]
+      if (handlers.length === 1) {
+        const result = new Result(handlers[0][0], emptyParam)
+        if (regexp === regExpMatchAll) {
+          match = () => result
+        } else if (handlers.length === 1 && !handlers[0][1]) {
+          match = (_, path) => (regexp.test(path) ? result : null)
+        }
+      }
     }
 
-    const matcher = this.matchers[method] || this.matchers[METHOD_NAME_OF_ALL]
-    if (!matcher) {
-      return null
+    match ||= (method, path) => {
+      const matcher = matchers[method] || matchers[METHOD_NAME_OF_ALL]
+      if (!matcher) {
+        return null
+      }
+
+      const match = path.match(matcher[0])
+      if (!match) {
+        return null
+      }
+
+      const index = match.indexOf('', 1)
+      const [handler, paramMap] = matcher[1][index]
+      if (!paramMap) {
+        return new Result(handler, emptyParam)
+      }
+
+      const params: Record<string, string> = {}
+      for (let i = 0; i < paramMap.length; i++) {
+        params[paramMap[i][0]] = match[paramMap[i][1]]
+      }
+      return new Result(handler, params)
     }
 
-    const [regexp, replacementMap, handlers] = matcher
-    if (regexp === true) {
-      // '*'
-      return new Result(handlers[0][0], {})
-    }
-
-    const match = path.match(regexp)
-    if (!match) {
-      return null
-    }
-    if (!replacementMap) {
-      // there is only one route and no capture
-      return new Result(handlers[0][0], {})
-    }
-
-    const index = match.indexOf('', 1)
-    const [handler, paramMap] = handlers[replacementMap[index]]
-    const params: Record<string, string> = {}
-    for (let i = 0; i < paramMap.length; i++) {
-      params[paramMap[i][0]] = match[paramMap[i][1]]
-    }
-    return new Result(handler, params)
+    this.match = match
+    return this.match(method, path)
   }
 
-  private buildAllMatchers() {
-    this.matchers ||= {}
-
+  private buildAllMatchers(): Record<string, Matcher<T>> {
+    const matchers: Record<string, Matcher<T>> = {}
     Object.keys(this.routes).forEach((method) => {
-      this.buildMatcher(method)
+      matchers[method] = this.buildMatcher(method)
     })
 
     delete this.routes // to reduce memory usage
+
+    return matchers
   }
 
-  private buildMatcher(method: string) {
-    this.matchers ||= {}
-
+  private buildMatcher(method: string): Matcher<T> {
     const trie = new Trie()
     const handlers: HandlerData<T>[] = []
 
@@ -76,38 +90,45 @@ export class RegExpRouter<T> extends Router<T> {
     const routes = targetMethods.flatMap((method) => this.routes[method] || [])
 
     if (routes.length === 0) {
-      this.matchers[method] = null
-      return
+      return null
     }
 
-    if (routes.length === 1 && routes[0][0] === '*') {
-      this.matchers[method] = [true, null, [[routes[0][1], []]]]
-      return
-    }
+    if (method === METHOD_NAME_OF_ALL) {
+      if (routes.length === 1 && routes[0][0] === '*') {
+        return [regExpMatchAll, [[routes[0][1], null]]]
+      }
 
-    if (routes.length === 1 && !routes[0][0].match(/:/)) {
-      // there is only one route and no capture
-      const tmp = routes[0][0].endsWith('*')
-        ? routes[0][0].replace(/\/\*$/, '(?:$|/)') // /path/to/* => /path/to(?:$|/)
-        : `${routes[0][0]}$` // /path/to/action => /path/to/action$
-      const regExpStr = `^${tmp.replace(/\*/g, '[^/]+')}` // /prefix/*/path/to => /prefix/[^/]+/path/to
-      this.matchers[method] = [new RegExp(regExpStr), null, [[routes[0][1], []]]]
-      return
+      if (routes.length === 1 && !routes[0][0].match(/:/)) {
+        // there is only one route and no capture
+        const tmp = routes[0][0].endsWith('*')
+          ? routes[0][0].replace(/\/\*$/, '(?:$|/)') // /path/to/* => /path/to(?:$|/)
+          : `${routes[0][0]}$` // /path/to/action => /path/to/action$
+        const regExpStr = `^${tmp.replace(/\*/g, '[^/]+')}` // /prefix/*/path/to => /prefix/[^/]+/path/to
+        return [new RegExp(regExpStr), [[routes[0][1], null]]]
+      }
     }
 
     for (let i = 0; i < routes.length; i++) {
       const paramMap = trie.insert(routes[i][0], i)
-      handlers[i] = [routes[i][1], paramMap]
+      handlers[i] = [routes[i][1], Object.keys(paramMap).length !== 0 ? paramMap : null]
     }
 
     const [regexp, indexReplacementMap, paramReplacementMap] = trie.buildRegExp()
     for (let i = 0; i < handlers.length; i++) {
       const paramMap = handlers[i][1]
-      for (let i = 0; i < paramMap.length; i++) {
-        paramMap[i][1] = paramReplacementMap[paramMap[i][1]]
+      if (paramMap) {
+        for (let i = 0; i < paramMap.length; i++) {
+          paramMap[i][1] = paramReplacementMap[paramMap[i][1]]
+        }
       }
     }
 
-    this.matchers[method] = [new RegExp(regexp), indexReplacementMap, handlers]
+    const handlerMap: HandlerData<T>[] = []
+    // using `in` because indexReplacementMap is a sparse array
+    for (const i in indexReplacementMap) {
+      handlerMap[i] = handlers[indexReplacementMap[i]]
+    }
+
+    return [regexp, handlerMap]
   }
 }

--- a/src/router/reg-exp-router/router.ts
+++ b/src/router/reg-exp-router/router.ts
@@ -7,13 +7,8 @@ type HandlerData<T> = [T, ParamMap]
 type Matcher<T> = [RegExp | true, ReplacementMap, HandlerData<T>[]]
 
 export class RegExpRouter<T> extends Router<T> {
-  routes?: {
-    [method: string]: Route<T>[]
-  } = {}
-
-  matchers?: {
-    [method: string]: Matcher<T> | null
-  } = null
+  routes?: Record<string, Route<T>[]> = {}
+  matchers?: Record<string, Matcher<T> | null> = null
 
   add(method: string, path: string, handler: T) {
     if (!this.routes) {
@@ -51,7 +46,7 @@ export class RegExpRouter<T> extends Router<T> {
 
     const index = match.indexOf('', 1)
     const [handler, paramMap] = handlers[replacementMap[index]]
-    const params: { [key: string]: string } = {}
+    const params: Record<string, string> = {}
     for (let i = 0; i < paramMap.length; i++) {
       params[paramMap[i][0]] = match[paramMap[i][1]]
     }


### PR DESCRIPTION
Hi,

I tried to optimize RegExpRouter.

### Summary

I think most middleware is applied to paths like '\*' or '/path/to/\*' that take no parameters.
In that case, parameter handling is not needed, so `match` can be optimized as follows.
https://github.com/yusukebe/hono/compare/master...usualoma:optimize-reg-exp-router?expand=1#diff-06f981941f95eecd6e249629fd9d5d4badaf8dfbe96ade6219e67691359df679R35-R38

And by optimizing the '\*' commonly used in middleware separately as described above, we can make it simpler for normal routing as well.
https://github.com/yusukebe/hono/compare/master...usualoma:optimize-reg-exp-router?expand=1#diff-06f981941f95eecd6e249629fd9d5d4badaf8dfbe96ade6219e67691359df679R43

### Benchmark

Since TrieRouter and RegExpRouter are already fast enough, the ranking may not be stable due to minute environmental influences, but the following results were obtained in my environment.

```
hono x 413,307 ops/sec ±3.71% (78 runs sampled)
hono with RegExpRouter x 445,681 ops/sec ±6.82% (66 runs sampled)
hono with RegExpRouter in this PR x 479,019 ops/sec ±6.31% (66 runs sampled)
itty-router x 67,901 ops/sec ±3.32% (88 runs sampled)
sunder x 115,183 ops/sec ±2.73% (80 runs sampled)
worktop x 72,526 ops/sec ±4.84% (80 runs sampled)
Fastest is hono with RegExpRouter in this PR
```

However, this is more than just a speedup on this benchmark.
* Speeds up middleware routing.
* Hopefully, even the following cases may be faster than TrieRouter 😛
    * https://twitter.com/yusukebe/status/1502069834712219650