### PR TITLE
fix: `encodeBase64/decodeBase64` throw Error if the argument is null

### DIFF
--- a/src/utils/crypto.test.ts
+++ b/src/utils/crypto.test.ts
@@ -17,15 +17,23 @@ describe('crypto', () => {
     expect(await sha1('abcdedf')).not.toBe('abcdef')
   })
 
-  it('encodeBaes64', async () => {
-    expect(await encodeBase64('hooooooooo')).toBe('aG9vb29vb29vbw==')
-    expect(await encodeBase64('炎')).toBe('54KO')
-    expect(await encodeBase64('abcdef')).not.toBe('abcdedf')
+  it('encodeBaes64', () => {
+    expect(encodeBase64('hooooooooo')).toBe('aG9vb29vb29vbw==')
+    expect(encodeBase64('炎')).toBe('54KO')
+    expect(encodeBase64('abcdef')).not.toBe('abcdedf')
+    expect(encodeBase64('')).toBe('')
+    expect(() => {
+      encodeBase64(null)
+    }).toThrow(TypeError)
   })
 
   it('decodeBaes64', async () => {
-    expect(await decodeBase64('aG9vb29vb29vbw==')).toBe('hooooooooo')
-    expect(await decodeBase64('54KO')).toBe('炎')
-    expect(await decodeBase64('abcdedf')).not.toBe('abcdef')
+    expect(decodeBase64('aG9vb29vb29vbw==')).toBe('hooooooooo')
+    expect(decodeBase64('54KO')).toBe('炎')
+    expect(decodeBase64('abcdedf')).not.toBe('abcdef')
+    expect(decodeBase64('')).toBe('')
+    expect(() => {
+      decodeBase64(null)
+    }).toThrowError(TypeError)
   })
 })

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -41,7 +41,10 @@ export const createHash = async (data: Data, algorithm: Algorithm): Promise<stri
   }
 }
 
-export const encodeBase64 = (str: string) => {
+export const encodeBase64 = (str: string): string => {
+  if (str === null) {
+    throw new TypeError('1st argument of "encodeBase64" should not be null.')
+  }
   try {
     const encoder = new TextEncoder()
     const bytes = encoder.encode(str)
@@ -61,7 +64,10 @@ export const encodeBase64 = (str: string) => {
   }
 }
 
-export const decodeBase64 = (str: string) => {
+export const decodeBase64 = (str: string): string => {
+  if (str === null) {
+    throw new TypeError('1st argument of "decodeBase64" should not be null.')
+  }
   try {
     const text = atob(str)
     const length = text.length


### PR DESCRIPTION
Fix #154 