### PR TITLE
feat: chained routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,21 @@ app.get('/post/:date{[0-9]+}/:title{[a-z]+}', (c) => {
 })
 ```
 
+### Chained route
+
+```js
+app
+  .get('/endpoint', (c) => {
+    return c.text('GET /endpoint')
+  })
+  .post((c) => {
+    return c.text('POST /endpoint')
+  })
+  .delete((c) => {
+    return c.text('DELETE /endpoint')
+  })
+```
+
 ### Nested route
 
 ```js
@@ -175,6 +190,9 @@ const app = new Hono()
 
 app.use('*', poweredBy())
 app.use('*', logger())
+// Or you can write:
+// app.use('*', poweredBy()).use(logger())
+
 app.use(
   '/auth/*',
   basicAuth({

--- a/src/context.ts
+++ b/src/context.ts
@@ -26,7 +26,7 @@ export class Context<RequestParamKeyType = string> {
     req: Request<RequestParamKeyType>,
     opts?: { res: Response; env: Env; event: FetchEvent }
   ) {
-    this.req = this.initRequest(req)
+    this.req = this.initRequest<RequestParamKeyType>(req)
     Object.assign(this, opts)
     this.#headers = {}
   }

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -144,6 +144,32 @@ describe('Routing', () => {
     expect(res.status).toBe(200)
     expect(await res.text()).toBe('post /user/register')
   })
+
+  describe('Chained route', () => {
+    app
+      .get('/chained/:abc', (c) => {
+        const abc = c.req.param('abc')
+        return c.text(`GET for ${abc}`)
+      })
+      .post((c) => {
+        const abc = c.req.param('abc')
+        return c.text(`POST for ${abc}`)
+      })
+    it('Should return 200 response from GET request', async () => {
+      const res = await app.request('http://localhost/chained/abc', { method: 'GET' })
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('GET for abc')
+    })
+    it('Should return 200 response from POST request', async () => {
+      const res = await app.request('http://localhost/chained/abc', { method: 'POST' })
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('POST for abc')
+    })
+    it('Should return 404 response from PUT request', async () => {
+      const res = await app.request('http://localhost/chained/abc', { method: 'PUT' })
+      expect(res.status).toBe(404)
+    })
+  })
 })
 
 describe('param and query', () => {
@@ -233,6 +259,27 @@ describe('Middleware', () => {
     expect(await res.text()).toBe('message')
     expect(res.headers.get('x-custom')).toBe('root')
     expect(res.headers.get('x-message-2')).toBe('custom-header-2')
+  })
+
+  describe.only('Chained route', () => {
+    app
+      .use('/chained/*', async (c, next) => {
+        c.req.headers.append('x-before', 'abc')
+        await next()
+      })
+      .use(async (c, next) => {
+        await next()
+        c.header('x-after', c.req.header('x-before'))
+      })
+      .get('/chained/abc', (c) => {
+        return c.text('GET chained')
+      })
+  })
+  it('Should return 200 response with chained route', async () => {
+    const res = await app.request('http://localhost/chained/abc')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('GET chained')
+    expect(res.headers.get('x-after')).toBe('abc')
   })
 })
 

--- a/src/hono.test.ts
+++ b/src/hono.test.ts
@@ -1,5 +1,5 @@
-import type { Context } from '@/context'
 import { Hono } from '@/hono'
+import { poweredBy } from '@/middleware/powered-by'
 
 describe('GET Request', () => {
   const app = new Hono()

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -79,6 +79,7 @@ export class Hono<P extends string> extends defineDynamicClass()<P> {
 
     this.#router = new this.routerClass()
     this.#middlewareRouters = []
+    this.#tempPath = null
   }
 
   private notFoundHandler: NotFoundHandler = (c: Context) => {

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -15,7 +15,7 @@ declare global {
 }
 
 export type Handler<RequestParamKeyType = string> = (
-  c: Context<RequestParamKeyType | string>,
+  c: Context<RequestParamKeyType>,
   next?: Next
 ) => Response | Promise<Response>
 export type MiddlewareHandler = (c: Context, next: Next) => Promise<void>
@@ -36,44 +36,42 @@ type ParamKeys<Path> = Path extends `${infer Component}/${infer Rest}`
   ? ParamKey<Component> | ParamKeys<Rest>
   : ParamKey<Path>
 
-function defineDynamicClass<T extends string[]>(
-  ...methods: T
-): {
-  new (): {
-    [K in T[number]]: <Path extends string>(path: Path, handler: Handler<ParamKeys<Path>>) => Hono
-  } & {
-    methods: T
-  }
-} {
-  return class {
-    get methods() {
-      return methods
-    }
-  } as any
+interface HandlerInterface<T extends string> {
+  <Path extends string>(path: Path, handler: Handler<ParamKeys<Path>>): Hono<Path>
+  <Path extends T>(handler: Handler<ParamKeys<T>>): Hono<Path>
 }
 
-export class Hono extends defineDynamicClass(
-  'get',
-  'post',
-  'put',
-  'delete',
-  'head',
-  'options',
-  'patch',
-  'all'
-) {
+const methods = ['get', 'post', 'put', 'delete', 'head', 'options', 'patch', 'all'] as const
+type Methods = typeof methods[number]
+
+function defineDynamicClass(): {
+  new <T extends string>(): {
+    [K in Methods]: HandlerInterface<T>
+  }
+} {
+  return class {} as any
+}
+
+export class Hono<P extends string> extends defineDynamicClass()<P> {
   readonly routerClass: { new (): Router<any> } = TrieRouter
   readonly strict: boolean = true // strict routing - default is true
   #router: Router<Handler>
   #middlewareRouters: Router<MiddlewareHandler>[]
   #tempPath: string
+  private path: string
 
-  constructor(init: Partial<Pick<Hono, 'routerClass' | 'strict'>> = {}) {
+  constructor(init: Partial<Pick<Hono<P>, 'routerClass' | 'strict'>> = {}) {
     super()
-
-    this.methods.map((method) => {
-      this[method] = <Path extends string>(path: Path, handler: Handler) => {
-        return this.addRoute(method, path, handler)
+    methods.map((method) => {
+      this[method] = <Path extends string>(
+        arg1: Path | Handler<ParamKeys<P>>,
+        arg2?: Handler<ParamKeys<Path>>
+      ) => {
+        if (typeof arg1 === 'string') {
+          this.path = arg1
+          return this.addRoute(method, this.path, arg2)
+        }
+        return this.addRoute(method, this.path, arg1)
       }
     })
 
@@ -81,7 +79,6 @@ export class Hono extends defineDynamicClass(
 
     this.#router = new this.routerClass()
     this.#middlewareRouters = []
-    this.#tempPath = null
   }
 
   private notFoundHandler: NotFoundHandler = (c: Context) => {
@@ -95,34 +92,43 @@ export class Hono extends defineDynamicClass(
     return c.text(message, 500)
   }
 
-  route(path: string): Hono {
-    const newHono: Hono = new Hono()
+  route(path: string): Hono<P> {
+    const newHono: Hono<P> = new Hono()
     newHono.#tempPath = path
     newHono.#router = this.#router
     return newHono
   }
 
-  use(path: string, middleware: MiddlewareHandler): void {
-    if (middleware.constructor.name !== 'AsyncFunction') {
+  use(path: string, middleware: MiddlewareHandler): Hono<P>
+  use(middleware: MiddlewareHandler): Hono<P>
+  use(arg1: string | MiddlewareHandler, arg2?: MiddlewareHandler): Hono<P> {
+    let handler: MiddlewareHandler
+    if (typeof arg1 === 'string') {
+      this.path = arg1
+      handler = arg2
+    } else {
+      handler = arg1
+    }
+    if (handler.constructor.name !== 'AsyncFunction') {
       throw new TypeError('middleware must be a async function!')
     }
     const router = new this.routerClass()
-    router.add(METHOD_NAME_OF_ALL, path, middleware)
+    router.add(METHOD_NAME_OF_ALL, this.path, handler)
     this.#middlewareRouters.push(router)
+    return this
   }
 
-  onError(handler: ErrorHandler): Hono {
+  onError(handler: ErrorHandler): Hono<P> {
     this.errorHandler = handler
     return this
   }
 
-  notFound(handler: NotFoundHandler): Hono {
+  notFound(handler: NotFoundHandler): Hono<P> {
     this.notFoundHandler = handler
     return this
   }
 
-  // addRoute('get', '/', handler)
-  private addRoute(method: string, path: string, handler: Handler): Hono {
+  private addRoute(method: string, path: string, handler: Handler): Hono<P> {
     method = method.toUpperCase()
     if (this.#tempPath) {
       path = mergePath(this.#tempPath, path)


### PR DESCRIPTION
Now, you can write:

```js
app
  .get('/endpoint', (c) => {
    return c.text('GET /endpoint')
  })
  .post((c) => {
    return c.text('POST /endpoint')
  })
  .delete((c) => {
    return c.text('DELETE /endpoint')
  })
```

With middleware:

```js
app.use('*', poweredBy()).use(logger())
```

Close #170